### PR TITLE
make streams consistent with simulation

### DIFF
--- a/src/Copilot/Compile/C99/CodeGen.hs
+++ b/src/Copilot/Compile/C99/CodeGen.hs
@@ -84,8 +84,10 @@ mkstep streams triggers exts = C.FunDef void "step" [] declns stmts where
   mktriggercheck (Trigger name guard args) = C.If guard' firetrigger where
     guard'      = C.Funcall (C.Ident $ guardname name) []
     firetrigger = [C.Expr $ C.Funcall (C.Ident name) args'] where
-      args'        = take (length args) (map argcall (argnames name))
-      argcall name = C.Funcall (C.Ident name) []
+      args' = map argcall (zip (argnames name) args)
+      argcall (aname, (maname, arg)) = case maname of
+        Just aname' -> C.Funcall (C.Ident (name ++ "_arg_" ++ aname')) []
+        Nothing     -> C.Funcall (C.Ident aname)  []
 
   -- Code to update the global buffer.
   mkupdatebuffer :: Stream -> C.Stmt

--- a/src/Copilot/Compile/C99/CodeGen.hs
+++ b/src/Copilot/Compile/C99/CodeGen.hs
@@ -153,5 +153,5 @@ gatherexprs :: [Stream] -> [Trigger] -> [UExpr]
 gatherexprs streams triggers =  map streamexpr streams
                              ++ concatMap triggerexpr triggers where
   streamexpr  (Stream _ _ expr ty)   = UExpr ty expr
-  triggerexpr (Trigger _ guard args) = UExpr Bool guard : args
+  triggerexpr (Trigger _ guard args) = UExpr Bool guard : (fmap snd args)
 

--- a/src/Copilot/Compile/C99/Compile.hs
+++ b/src/Copilot/Compile/C99/Compile.hs
@@ -22,10 +22,13 @@ compile prefix spec = do
       hfile = render $ pretty $ C.translate $ compileh spec
 
       -- TODO: find a nicer solution using annotated AST's
+      -- Should figure out exactly which headers are needed, based on what
+      -- is used.
       cmacros = unlines [ "#include <stdint.h>"
                         , "#include <stdbool.h>"
                         , "#include <string.h>"
                         , "#include <stdlib.h>"
+                        , "#include <math.h>"
                         , ""
                         , "#include \"" ++ prefix ++ ".h\""
                         , ""

--- a/src/Copilot/Compile/C99/Compile.hs
+++ b/src/Copilot/Compile/C99/Compile.hs
@@ -25,6 +25,7 @@ compile prefix spec = do
       cmacros = unlines [ "#include <stdint.h>"
                         , "#include <stdbool.h>"
                         , "#include <string.h>"
+                        , "#include <stdlib.h>"
                         , ""
                         , "#include \"" ++ prefix ++ ".h\""
                         , ""

--- a/src/Copilot/Compile/C99/Compile.hs
+++ b/src/Copilot/Compile/C99/Compile.hs
@@ -81,9 +81,9 @@ compilec spec = C.TransUnit declns funs where
       argdefs  = map arggen (zip (argnames name) args)
 
       arggen :: (String, (Maybe String, UExpr)) -> C.FunDef
-      arggen (argname, (mname, UExpr ty expr)) = case mname of
-        Just name -> genfun name expr ty
-        Nothing   -> genfun argname expr ty
+      arggen (aname, (maname, UExpr ty expr)) = case maname of
+        Just aname' -> genfun (name ++ "_arg_" ++ aname') expr ty
+        Nothing     -> genfun aname expr ty
 
 -- | Generate the .h file from a spec.
 compileh :: Spec -> C.TransUnit

--- a/src/Copilot/Compile/C99/Compile.hs
+++ b/src/Copilot/Compile/C99/Compile.hs
@@ -80,8 +80,10 @@ compilec spec = C.TransUnit declns funs where
       guarddef = genfun (guardname name) guard Bool
       argdefs  = map arggen (zip (argnames name) args)
 
-      arggen :: (String, UExpr) -> C.FunDef
-      arggen (argname, UExpr ty expr) = genfun argname expr ty
+      arggen :: (String, (Maybe String, UExpr)) -> C.FunDef
+      arggen (argname, (mname, UExpr ty expr)) = case mname of
+        Just name -> genfun name expr ty
+        Nothing   -> genfun argname expr ty
 
 -- | Generate the .h file from a spec.
 compileh :: Spec -> C.TransUnit
@@ -114,7 +116,9 @@ compileh spec = C.TransUnit declns [] where
     extfundecln (Trigger name _ args) = C.FunDecln Nothing cty name params where
         cty    = C.TypeSpec C.Void
         params = map mkparam $ zip (argnames name) args
-        mkparam (name, UExpr ty _) = C.Param (transtype ty) name
+        mkparam (name, (mname, UExpr ty _)) = case mname of
+          Just name' -> C.Param (transtype ty) name'
+          Nothing    -> C.Param (transtype ty) name
 
   -- Declaration for the step function.
   stepdecln :: C.Decln

--- a/src/Copilot/Compile/C99/External.hs
+++ b/src/Copilot/Compile/C99/External.hs
@@ -32,8 +32,8 @@ gatherexts streams triggers = streamsexts `extunion` triggersexts where
     guardexts = exprexts guard
     argexts   = concat $ map uexprexts args
 
-  uexprexts :: UExpr -> [External]
-  uexprexts (UExpr _ expr) = exprexts expr
+  uexprexts :: (Maybe String, UExpr) -> [External]
+  uexprexts (_, UExpr _ expr) = exprexts expr
 
   exprexts :: Expr a -> [External]
   exprexts expr = let rec = exprexts in case expr of

--- a/src/Copilot/Compile/C99/Translate.hs
+++ b/src/Copilot/Compile/C99/Translate.hs
@@ -112,22 +112,25 @@ transop3 op e1 e2 e3 = case op of
 constty :: Type a -> a -> C.Expr
 constty ty = case ty of
   Bool   -> C.LitBool
-  Int8   -> C.LitInt . fromIntegral
-  Int16  -> C.LitInt . fromIntegral
-  Int32  -> C.LitInt . fromIntegral
-  Int64  -> C.LitInt . fromIntegral
-  Word8  -> C.LitInt . fromIntegral
-  Word16 -> C.LitInt . fromIntegral
-  Word32 -> C.LitInt . fromIntegral
-  Word64 -> C.LitInt . fromIntegral
-  Float  -> C.LitFloat
-  Double -> C.LitDouble
+  Int8   -> explicit_type ty . C.LitInt . fromIntegral
+  Int16  -> explicit_type ty . C.LitInt . fromIntegral
+  Int32  -> explicit_type ty . C.LitInt . fromIntegral
+  Int64  -> explicit_type ty . C.LitInt . fromIntegral
+  Word8  -> explicit_type ty . C.LitInt . fromIntegral
+  Word16 -> explicit_type ty . C.LitInt . fromIntegral
+  Word32 -> explicit_type ty . C.LitInt . fromIntegral
+  Word64 -> explicit_type ty . C.LitInt . fromIntegral
+  Float  -> explicit_type ty . C.LitFloat
+  Double -> explicit_type ty . C.LitDouble
   Struct _ -> \v -> C.InitVal (transtypename ty) (map fieldinit (toValues v))
     where
       fieldinit (Value ty (Field val)) = C.InitExpr $ constty ty val
   Array ty' -> \v -> C.InitVal (transtypename ty) (map valinit (arrayelems v))
     where
       valinit = C.InitExpr . constty ty'
+
+explicit_type :: Type a -> C.Expr -> C.Expr
+explicit_type ty = C.Cast (transtypename ty)
 
 -- | Translate a Copilot type to a C99 type.
 transtype :: Type a -> C.Type


### PR DESCRIPTION
An extra entry is added to the stream arrays, so that when we can always
update an entry which is not going to be read on that same step.

Fixes this https://github.com/Copilot-Language/copilot/issues/57 as well as other similar inconsistency bugs I found while working on my first copilot project.

