### PR TITLE
include stdlib.h and math.h in generated c

### DIFF
--- a/src/Copilot/Compile/C99/Compile.hs
+++ b/src/Copilot/Compile/C99/Compile.hs
@@ -22,10 +22,13 @@ compile prefix spec = do
       hfile = render $ pretty $ C.translate $ compileh spec
 
       -- TODO: find a nicer solution using annotated AST's
+      -- Should figure out exactly which headers are needed, based on what
+      -- is used.
       cmacros = unlines [ "#include <stdint.h>"
                         , "#include <stdbool.h>"
                         , "#include <string.h>"
                         , "#include <stdlib.h>"
+                        , "#include <math.h>"
                         , ""
                         , "#include \"" ++ prefix ++ ".h\""
                         , ""

--- a/src/Copilot/Compile/C99/Compile.hs
+++ b/src/Copilot/Compile/C99/Compile.hs
@@ -25,6 +25,7 @@ compile prefix spec = do
       cmacros = unlines [ "#include <stdint.h>"
                         , "#include <stdbool.h>"
                         , "#include <string.h>"
+                        , "#include <stdlib.h>"
                         , ""
                         , "#include \"" ++ prefix ++ ".h\""
                         , ""


### PR DESCRIPTION
Ideally we'd figure out exactly what is needed based on the abstract syntax, but this coarse fix suits my needs.