### PR TITLE
support for named trigger arguments

### DIFF
--- a/src/Copilot/Compile/C99/CodeGen.hs
+++ b/src/Copilot/Compile/C99/CodeGen.hs
@@ -76,8 +76,10 @@ mkstep streams triggers exts = C.FunDef void "step" [] declns stmts where
   mktriggercheck (Trigger name guard args) = C.If guard' firetrigger where
     guard'      = C.Funcall (C.Ident $ guardname name) []
     firetrigger = [C.Expr $ C.Funcall (C.Ident name) args'] where
-      args'        = take (length args) (map argcall (argnames name))
-      argcall name = C.Funcall (C.Ident name) []
+      args' = map argcall (zip (argnames name) args)
+      argcall (aname, (maname, arg)) = case maname of
+        Just aname' -> C.Funcall (C.Ident (name ++ "_arg_" ++ aname')) []
+        Nothing     -> C.Funcall (C.Ident aname)  []
 
   -- Code to update the global buffer.
   mkupdatebuffer :: Stream -> C.Stmt

--- a/src/Copilot/Compile/C99/CodeGen.hs
+++ b/src/Copilot/Compile/C99/CodeGen.hs
@@ -145,5 +145,5 @@ gatherexprs :: [Stream] -> [Trigger] -> [UExpr]
 gatherexprs streams triggers =  map streamexpr streams
                              ++ concatMap triggerexpr triggers where
   streamexpr  (Stream _ _ expr ty)   = UExpr ty expr
-  triggerexpr (Trigger _ guard args) = UExpr Bool guard : args
+  triggerexpr (Trigger _ guard args) = UExpr Bool guard : (fmap snd args)
 

--- a/src/Copilot/Compile/C99/Compile.hs
+++ b/src/Copilot/Compile/C99/Compile.hs
@@ -81,9 +81,9 @@ compilec spec = C.TransUnit declns funs where
       argdefs  = map arggen (zip (argnames name) args)
 
       arggen :: (String, (Maybe String, UExpr)) -> C.FunDef
-      arggen (argname, (mname, UExpr ty expr)) = case mname of
-        Just name -> genfun name expr ty
-        Nothing   -> genfun argname expr ty
+      arggen (aname, (maname, UExpr ty expr)) = case maname of
+        Just aname' -> genfun (name ++ "_arg_" ++ aname') expr ty
+        Nothing     -> genfun aname expr ty
 
 -- | Generate the .h file from a spec.
 compileh :: Spec -> C.TransUnit

--- a/src/Copilot/Compile/C99/Compile.hs
+++ b/src/Copilot/Compile/C99/Compile.hs
@@ -80,8 +80,10 @@ compilec spec = C.TransUnit declns funs where
       guarddef = genfun (guardname name) guard Bool
       argdefs  = map arggen (zip (argnames name) args)
 
-      arggen :: (String, UExpr) -> C.FunDef
-      arggen (argname, UExpr ty expr) = genfun argname expr ty
+      arggen :: (String, (Maybe String, UExpr)) -> C.FunDef
+      arggen (argname, (mname, UExpr ty expr)) = case mname of
+        Just name -> genfun name expr ty
+        Nothing   -> genfun argname expr ty
 
 -- | Generate the .h file from a spec.
 compileh :: Spec -> C.TransUnit
@@ -114,7 +116,9 @@ compileh spec = C.TransUnit declns [] where
     extfundecln (Trigger name _ args) = C.FunDecln Nothing cty name params where
         cty    = C.TypeSpec C.Void
         params = map mkparam $ zip (argnames name) args
-        mkparam (name, UExpr ty _) = C.Param (transtype ty) name
+        mkparam (name, (mname, UExpr ty _)) = case mname of
+          Just name' -> C.Param (transtype ty) name'
+          Nothing    -> C.Param (transtype ty) name
 
   -- Declaration for the step function.
   stepdecln :: C.Decln

--- a/src/Copilot/Compile/C99/External.hs
+++ b/src/Copilot/Compile/C99/External.hs
@@ -32,8 +32,8 @@ gatherexts streams triggers = streamsexts `extunion` triggersexts where
     guardexts = exprexts guard
     argexts   = concat $ map uexprexts args
 
-  uexprexts :: UExpr -> [External]
-  uexprexts (UExpr _ expr) = exprexts expr
+  uexprexts :: (Maybe String, UExpr) -> [External]
+  uexprexts (_, UExpr _ expr) = exprexts expr
 
   exprexts :: Expr a -> [External]
   exprexts expr = let rec = exprexts in case expr of


### PR DESCRIPTION
This can be useful when, for instance, you want to give a header file to a developer who doesn't care that you generated your C from copilot.